### PR TITLE
change references to use new fiberplane-rs structure

### DIFF
--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -61,7 +61,7 @@ fn generate_config_method(writer: &mut BufWriter<File>) -> Result<()> {
 }
 
 fn generate_client_method(server: &Server, writer: &mut BufWriter<File>) -> Result<()> {
-    let mut description = server
+    let description = server
         .description
         .as_ref()
         .ok_or_else(|| anyhow!("Server {:?} does not have `description`", server))?;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,11 +1,9 @@
 use crate::client_config::generate_client_configs;
-use crate::models::generate_models;
 use crate::routes::generate_routes;
 use anyhow::{anyhow, bail, Context, Result};
 use cargo_toml::{Dependency, DependencyDetail, DepsSet, Manifest};
 use okapi::openapi3::OpenApi;
-use std::fs;
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
@@ -114,25 +112,25 @@ fn add_dependencies(dependencies: &mut DepsSet, local_dependencies: bool) -> Res
     // base64uuid
     dependencies.insert(
         "base64uuid".to_string(),
-        fp_dependency("base64uuid", local_dependencies),
+        fp_dependency("base64uuid", local_dependencies, vec![]),
     );
 
-    // fiberplane
+    // fiberplane-models
     dependencies.insert(
-        "fiberplane".to_string(),
-        fp_dependency("fiberplane", local_dependencies),
+        "fiberplane-models".to_string(),
+        fp_dependency("fiberplane-models", local_dependencies, vec![]),
     );
 
-    // fp-templates
+    // fiberplane-templates
     dependencies.insert(
-        "fp-templates".to_string(),
-        fp_dependency("fp-templates", local_dependencies),
+        "fiberplane-templates".to_string(),
+        fp_dependency("fiberplane-templates", local_dependencies, vec!["types"]),
     );
 
     // time
     {
         let mut dependency = DependencyDetail::default();
-        dependency.version = Some("0".to_string());
+        dependency.version = Some("0.3".to_string());
         dependency.features.push("parsing".to_string());
         dependency.features.push("formatting".to_string());
         dependency.features.push("serde-human-readable".to_string());
@@ -147,8 +145,9 @@ fn add_dependencies(dependencies: &mut DepsSet, local_dependencies: bool) -> Res
 }
 
 /// declare a dependency which lives within the fiberplane-rs repository
-fn fp_dependency(name: &str, local_dependency: bool) -> Dependency {
+fn fp_dependency(name: &str, local_dependency: bool, features: Vec<&str>) -> Dependency {
     let mut dependency = DependencyDetail::default();
+    dependency.features = features.into_iter().map(str::to_string).collect();
 
     if local_dependency {
         dependency.path = Some(format!("../{name}"));

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,9 +1,9 @@
 use crate::types::map_type;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result};
 use check_keyword::CheckKeyword;
 use convert_case::{Case, Casing};
 use okapi::openapi3::{Components, SchemaObject};
-use schemars::schema::{InstanceType, Schema, SingleOrVec};
+use schemars::schema::Schema;
 use schemars::Set;
 use std::fs;
 use std::fs::File;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3,8 +3,7 @@ use crate::types::{map_type, resolve, ResolveTarget, ResolvedReference};
 use anyhow::{anyhow, bail, Context, Result};
 use convert_case::{Case, Casing};
 use okapi::openapi3::{
-    Components, MediaType, Operation, Parameter, ParameterValue, PathItem, RefOr, RequestBody,
-    Response,
+    Components, MediaType, Operation, Parameter, ParameterValue, PathItem, RefOr,
 };
 use okapi::Map;
 use regex::Regex;
@@ -45,8 +44,28 @@ pub(crate) fn generate_routes(
     //write!(writer, "pub mod models;\n\n")?;
 
     write!(writer, "pub mod models {{\n")?;
-    write!(writer, "    pub use fiberplane::protocols::core::*;\n")?;
-    write!(writer, "    pub use fp_templates::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::notebooks::*;\n")?;
+    write!(
+        writer,
+        "    pub use fiberplane_models::notebooks::operations::*;\n"
+    )?;
+    write!(writer, "    pub use fiberplane_models::blobs::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::comments::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::data_sources::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::events::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::files::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::formatting::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::labels::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::names::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::proxies::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::query_data::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::realtime::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::sorting::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::timestamps::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::tokens::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::users::*;\n")?;
+    write!(writer, "    pub use fiberplane_models::workspaces::*;\n")?;
+    write!(writer, "    pub use fiberplane_templates::*;\n")?;
     write!(writer, "}}\n\n")?;
 
     for (endpoint, item) in paths {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use convert_case::{Case, Casing};
-use okapi::openapi3::{Components, Parameter, RefOr, RequestBody, Response, Responses};
-use schemars::schema::{InstanceType, Schema, SchemaObject, SingleOrVec};
+use okapi::openapi3::{Components, Parameter, RefOr, RequestBody, Response};
+use schemars::schema::{InstanceType, SchemaObject, SingleOrVec};
 use std::borrow::Cow;
 
 pub(crate) fn map_type<'a>(


### PR DESCRIPTION
- add imports referencing new `fiberplane_models` crate and renamed `fiberplane_templates` crate
- increase required `time` version to `0.3`
- remove unused imports
- fix clippy

fixes FP-2642