### PR TITLE
generate descriptions as `#[doc = "..."]` attributes to allow multi line descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Fiberplane Rust client generator for OpenAPI"
 authors = ["Fiberplane <info@fiberplane.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fiberplane/fp-openapi-rust-gen"
-msrv = "1.58.1"
+rust-version = "1.58.1"
 
 [dependencies]
 anyhow = "1.0.66"

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -130,7 +130,7 @@ fn generate_route(
     components: &Components,
 ) -> Result<()> {
     if let Some(description) = &operation.description {
-        writeln!(writer, "/// {}", description)?;
+        writeln!(writer, "#[doc = r#\"{}\"#]", description)?;
     }
 
     let method_name = operation


### PR DESCRIPTION
also some small code cleanup. fixes FP-2811